### PR TITLE
Enforce address with checksum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
         "@heroicons/react": "^1.0.5",
         "@xmtp/xmtp-js": "^6.0.0",
         "framer-motion": "^6.3.11",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@ethersproject/abstract-signer": "^5.7.0",
+    "@ethersproject/address": "^5.7.0",
     "@heroicons/react": "^1.0.5",
     "@xmtp/xmtp-js": "^6.0.0",
     "framer-motion": "^6.3.11",

--- a/src/components/XmtpProvider.tsx
+++ b/src/components/XmtpProvider.tsx
@@ -1,6 +1,7 @@
+import { getAddress } from '@ethersproject/address'
 import { Dict } from '@chakra-ui/utils'
 import { ChakraProvider } from '@chakra-ui/react'
-import React from 'react'
+import React, { useCallback } from 'react'
 import storage from 'localforage'
 import { Reducer, useEffect, useReducer, useState } from 'react'
 import { Client } from '@xmtp/xmtp-js'
@@ -38,7 +39,7 @@ export const XmtpProvider: React.FC<XmtpProviderProps> = ({
   theme,
 }) => {
   const [client, setClient] = useState<Client | null>()
-  const [recipient, setRecipient] = useState<string>()
+  const [recipient, _setRecipient] = useState<string>()
   const [loadingConversations, setLoadingConversations] =
     useState<boolean>(true)
 
@@ -50,6 +51,14 @@ export const XmtpProvider: React.FC<XmtpProviderProps> = ({
     state.set(conversation.peerAddress, conversation)
     return state
   }, new Map())
+
+  const setRecipient = useCallback(
+    (address?: string) => {
+      const addr = address ? getAddress(address) : undefined
+      _setRecipient(addr)
+    },
+    [_setRecipient]
+  )
 
   useEffect(() => {
     if (signer) {


### PR DESCRIPTION
When setting the recipient, we need to ensure that the address is the version with the checksum, XMTP does treat addresses with different formatting differently and an address with the wrong formatting will have an error