### PR TITLE
Fix conversation tile loading

### DIFF
--- a/src/components/ConversationsList/ConversationTile.tsx
+++ b/src/components/ConversationsList/ConversationTile.tsx
@@ -18,7 +18,7 @@ const ConversationTile = ({
   isSelected,
   onClick,
 }: ConversationTileProps): JSX.Element | null => {
-  const messages = useMessages()
+  const messages = useMessages(peerAddress)
   const latestMessage = messages[messages.length - 1]
   return (
     <LinkBox key={peerAddress}>

--- a/src/hooks/useFetchMessages.ts
+++ b/src/hooks/useFetchMessages.ts
@@ -4,7 +4,7 @@ import useChat from './useChat'
 type OnMessageCallback = () => void
 
 const useFetchMessages = (
-  peerAddress?: string,
+  peerAddress: string | undefined,
   onMessageCallback?: OnMessageCallback
 ) => {
   const { client, addMessages } = useChat()

--- a/src/hooks/useLookup.ts
+++ b/src/hooks/useLookup.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Account } from '../contexts/xmtp'
 import useChat from './useChat'
 
-const useLookup = (address?: string) => {
+const useLookup = (address: string | undefined) => {
   const { lookupAddress } = useChat()
   const [account, setAccount] = useState<Account>({})
   const [loading, setLoading] = useState<boolean>(false)

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import useChat from './useChat'
 
-const useMessages = (peerAddress?: string) => {
+const useMessages = (peerAddress: string | undefined) => {
   const { store } = useChat()
 
   return useMemo(() => {

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 import useChat from './useChat'
 
-const useSendMessage = (peerAddress?: string) => {
+const useSendMessage = (peerAddress: string | undefined) => {
   const { client } = useChat()
   const [loading, setLoading] = useState(false)
 


### PR DESCRIPTION
Fix an issue with the loading message appearing in the conversation tile. 
This was due to a missing parameter that typescript didn't catch. I added stricter parameters for hooks to ensure this does not happen again