### PR TITLE
Normalize height of button

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -45,7 +45,7 @@ const AddressInput = ({
 }: AddressInputProps) => (
   <Flex alignItems="center" padding="3">
     <Link onClick={onCancel} marginRight="2">
-      <ChevronLeftIcon width="20" />
+      <ChevronLeftIcon width="20" height="32" />
     </Link>
     <RecipientControl value={recipient} onSubmit={onSubmit} />
     {children}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/33982052/232444614-cb4b84df-d77a-447e-a3ca-d9cd0d6cb168.png)


After:
![image](https://user-images.githubusercontent.com/33982052/232444488-579df11c-f12a-4252-9df6-0e81376dba78.png)

This height is O-mee friendly, and shouldn't fix any styling as O-mee uses 32px height as well.
